### PR TITLE
Derive Copy for small event types (if allowed)

### DIFF
--- a/app.zk_scrypto.rs
+++ b/app.zk_scrypto.rs
@@ -13,14 +13,14 @@ mod zk_soundness_vault {
         pub spent: bool,
     }
 
-    #[derive(ScryptoSbor, Debug, Clone)]
+     #[derive(ScryptoSbor, Debug, Clone, Copy)]
     pub struct DepositEvent {
         pub note_id: u64,
         pub amount: Decimal,
         pub opaque_commitment: String,
     }
 
-    #[derive(ScryptoSbor, Debug, Clone)]
+    #[derive(ScryptoSbor, Debug, Clone, Copy)]
     pub struct WithdrawalEvent {
         pub note_id: u64,
         pub amount: Decimal,


### PR DESCRIPTION
Make events trivially copyable (small structs).