### PR TITLE
Add a constant for the resource (RADIX_TOKEN)

### DIFF
--- a/app.zk_scrypto.rs
+++ b/app.zk_scrypto.rs
@@ -1,7 +1,7 @@
 // File: app.zk_scrypto.rs
 
 use scrypto::prelude::*;
-
+ const VAULT_RESOURCE: ResourceAddress = RADIX_TOKEN;
 #[blueprint]
 mod zk_soundness_vault {
     use scrypto::prelude::*;


### PR DESCRIPTION
Avoid hardcoding RADIX_TOKEN in multiple places.