### PR TITLE
helper: get_unspent_note_count (approximation)

### DIFF
--- a/app.zk_scrypto.rs
+++ b/app.zk_scrypto.rs
@@ -132,4 +132,17 @@ mod zk_soundness_vault {
             self.notes.get(&note_id)
         }
     }
+            /// Approximate count of unspent notes by scanning the store.
+        /// This is O(n) over the number of notes and intended for light use.
+        pub fn get_unspent_note_count(&self) -> u64 {
+            let mut count: u64 = 0;
+            for (id, note) in self.notes.iter() {
+                let _ = id; // silence unused warning if needed
+                if !note.spent {
+                    count += 1;
+                }
+            }
+            count
+        }
+
 }


### PR DESCRIPTION
Rough idea of how many notes are still live.