### PR TITLE
Emit more neutral deposit event “opaque” string

### DIFF
--- a/app.zk_scrypto.rs
+++ b/app.zk_scrypto.rs
@@ -78,7 +78,7 @@ mod zk_soundness_vault {
             emit_event(DepositEvent {
                 note_id,
                 amount,
-                opaque_commitment: String::from("opaque:stored-off-chain (Aztec/Zama style)"),
+                               opaque_commitment: String::from("opaque:stored-off-chain"),
             });
 
             note_id


### PR DESCRIPTION
Make the event string less hardcoded to Aztec/Zama.