### PR TITLE
Add a view: get_locked_balance_in_vault

### DIFF
--- a/app.zk_scrypto.rs
+++ b/app.zk_scrypto.rs
@@ -123,6 +123,11 @@ mod zk_soundness_vault {
         pub fn get_total_locked(&self) -> Decimal {
             self.total_locked
         }
+        /// Return the current XRD balance of the underlying vault.
+        /// Invariants should ensure this equals `total_locked`.
+        pub fn get_locked_balance_in_vault(&self) -> Decimal {
+            self.vault.amount()
+        }
 
         pub fn get_note_count(&self) -> u64 {
             self.next_note_id


### PR DESCRIPTION
Expose the underlying vault’s balance (should match total_locked).