### PR TITLE
Add debug helper to check invariant (if base has it)

### DIFF
--- a/scripts.zk_scrypto.rs
+++ b/scripts.zk_scrypto.rs
@@ -59,6 +59,12 @@ mod zk_soundness_vault_scripts {
         pub fn get_total_locked_via_script(&self) -> Decimal {
             self.vault.get_total_locked()
         }
+        
+        /// Debug view: forward the vault's soundness invariant check.
+        /// Returns true if total_locked == vault.amount().
+        pub fn check_soundness_invariant_via_script(&self) -> bool {
+            self.vault.check_soundness_invariant()
+        }
 
         /// Read-only helper: how many notes have been created so far.
         pub fn get_note_count_via_script(&self) -> u64 {


### PR DESCRIPTION
For dashboards / debugging (assuming you added check_soundness_invariant in the base vault as we suggested earlier).