### PR TITLE
wrapper for get_note_metadata (if needed by UIs)

### DIFF
--- a/scripts.zk_scrypto.rs
+++ b/scripts.zk_scrypto.rs
@@ -64,5 +64,10 @@ mod zk_soundness_vault_scripts {
         pub fn get_note_count_via_script(&self) -> u64 {
             self.vault.get_note_count()
         }
+                /// Read-only helper: fetch metadata for a specific note id.
+        pub fn get_note_metadata_via_script(&self, note_id: u64) -> Option<Note> {
+            self.vault.get_note_metadata(note_id)
+        }
+
     }
 }


### PR DESCRIPTION
UIs can query notes via the scripts component only.