### PR TITLE
Docs: update repository structure section and mention scripts.zk_scry…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Minimal Scrypto blueprint for Radix that demonstrates a privacy inspired vault f
 
 The blueprint stores deposits as opaque notes keyed by a commitment string while keeping the on ledger logic focused on simple accounting and event emission. Real zk and FHE logic is intentionally left off chain.
 
-Repository contains exactly two files:
+Repository contains three main files:
 
-1. app.zk_scrypto.rs – Scrypto blueprint implementing the vault
-2. README.md – this documentation file
+  1. app.zk_scrypto.rs – Scrypto blueprint implementing the vault
+  2. scripts.zk_scrypto.rs – example Scrypto scripts for instantiating and calling the vault
+  3. README.md – this documentation file
+
 
 ---
 


### PR DESCRIPTION
…pto.rs

## Summary

The README currently says that the repository contains "exactly two files" (the blueprint and the README), but the repo now also includes `scripts.zk_scrypto.rs`. This PR updates the repository structure section to accurately reflect the current layout and adds a brief description of the scripts file.

## Changes

- Update the "Repository structure" section in `README.md`:
  - Change the text "exactly two files" to reflect three files.
  - Add `scripts.zk_scrypto.rs` to the numbered list.
  - Add a short sentence describing that `scripts.zk_scrypto.rs` contains example Scrypto scripts for interacting with the vault (e.g. instantiation / deposit / withdraw helpers).

## Rationale

- Keeps the documentation in sync with the actual contents of the repository.
- Makes it easier for newcomers to discover the script helpers and understand how they relate to the main blueprint.