### PR TITLE
add Quickstart usage section with example vault interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,20 @@ No other files introduce name collisions with the zk_soundness_vault module or Z
 
 If compilation fails due to version differences, adjust imports and the globalize pattern in the instantiate function to match your Scrypto release while preserving the core struc
 
+## Usage (Quickstart examples)
+
+> Note: The exact commands / manifest syntax may differ slightly depending on your Scrypto / Babylon tooling version. Treat the snippets below as templates.
+
+### 1. Instantiate the vault
+
+- Build and publish your Scrypto package as usual.
+- Then instantiate the `ZkSoundnessVault` blueprint using a transaction manifest similar to:
+
+```text
+# Pseudo-manifest (adjust for your tooling)
+CALL_FUNCTION
+  Address("PACKAGE_ADDRESS_HERE")
+  "zk_soundness_vault"
+  "instantiate_zk_soundness_vault"
+  ;
+


### PR DESCRIPTION
## Summary

The README explains the concept and how to build the package, but it does not show a concrete "copy & paste" style example of how to actually instantiate and interact with the vault using Scrypto tooling. This PR adds a small "Quickstart / Usage" section with example commands / manifests so that users can try the blueprint end-to-end more easily.

## Changes

- Add a new section `## Usage (Quickstart examples)` to `README.md` after the `## Building` section.
- Include:
  - A short example of instantiating the `ZkSoundnessVault` blueprint (e.g. using a transaction manifest placeholder).
  - An example for depositing XRD with a sample commitment string.
  - An example for withdrawing by note id.
- Use placeholder addresses / IDs (e.g. `PACKAGE_ADDRESS_HERE`, `COMPONENT_ADDRESS_HERE`, `NOTE_ID_HERE`) and explain that users need to substitute their own values.

## Rationale

- Gives new users a clear starting point to test the vault without reading the entire blueprint code.
- Encourages experimentation with the zk / FHE integration ideas described in the README.